### PR TITLE
Add check-ci not using tty

### DIFF
--- a/templates/.gitlab-ci.yml
+++ b/templates/.gitlab-ci.yml
@@ -6,4 +6,4 @@ job-analyze:
 job-check:
   stage: test
   script:
-    - make check
+    - make check-ci

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -30,20 +30,23 @@ imagedev:
 
 vendor: imagedev
 	$(runcmd) ./hack/vendor.sh
-	chown -R $(USER):$(USER) ./vendor
-	chown -R $(USER):$(USER) ./Godeps
+	sudo chown -R $(USER):$(USER) ./vendor
+	sudo chown -R $(USER):$(USER) ./Godeps
 
 build: imagedev
 	$(runcmd) go build -v -ldflags "-X main.Version=$(gitversion)" -o ./cmd/{{.Name}}/{{.Name}} ./cmd/{{.Name}}/main.go
 
 analyze:
-	$(runcmd) ./hack/analyze.sh
+	$(runshell) ./hack/analyze.sh
 
 check: imagedev
+	$(runshell) ./hack/check.sh $(pkg) $(test)
+
+check-ci: imagedev
 	$(runcmd) ./hack/check.sh $(pkg) $(test)
 
 coverage: imagedev
-	$(runcmd) ./hack/coverage.sh
+	$(runshell) ./hack/coverage.sh
 
 coverage-show: coverage
 	xdg-open fullcov.html


### PR DESCRIPTION
Basically running docker without tty and interaction disabled control-c, but the gitlab CI do not have a tty and breaks because of that. We could check to add a tty or something like it (pseudo) on the CI environment...but for now this should make it.