### PR TITLE
Add gomodcachedir to dockerignore

### DIFF
--- a/gootstrap.go
+++ b/gootstrap.go
@@ -32,6 +32,7 @@ func CreateProject(cfg Config, rootdir string) error {
 		"hack/Dockerfile":                  template.DockerfileDev,
 		"hack/githooks/pre-commit":         template.GitHookPreCommit,
 		".gitignore":                       template.GitIgnore,
+		".dockerignore":                    template.DockerIgnore,
 		".gitlab-ci.yml":                   template.GitlabCI,
 		"cmd/{{.Project}}/{{.Project}}.go": template.Cmd,
 	}

--- a/template/dockerignore.go
+++ b/template/dockerignore.go
@@ -1,0 +1,3 @@
+package template
+
+const DockerIgnore = `.gomodcachedir`

--- a/template/gitignore.go
+++ b/template/gitignore.go
@@ -1,6 +1,6 @@
 package template
 
 const GitIgnore = `cmd/{{.Project}}/{{.Project}}
-.gomodcache
+.gomodcachedir
 .devimgbuild.logs
 `


### PR DESCRIPTION
Every time that you run a test  `.gomodcachedir` is sent to the docker context.

It is ok, but when your dependencies occupy a few MB it starts to be a bit annoying =P

As the `.gomodcachedir` dir is accessed through a docker volume, it was added into the `.dockerignore` file.

Plus the dir name in the `.gitignore` was fixed 