### PR TITLE
Fix for mac os

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 os:
   - linux
+  - osx
 
 sudo: required
 
@@ -9,8 +10,8 @@ services:
 language: go
 
 go:
-  - tip
-  - 1.12
+  - "tip"
+  - "1.12"
 
 script:
   - ./check.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - osx
 
 sudo: required
 

--- a/template/dockerfile.go
+++ b/template/dockerfile.go
@@ -11,8 +11,8 @@ ARG USER
 ARG USER_ID
 ARG GROUP_ID
 
-RUN groupadd -g ${GROUP_ID} ${USER} && \
-    useradd -m -g ${GROUP_ID} -u ${USER_ID} ${USER}
+RUN groupadd -f -g ${GROUP_ID} ${USER} && \
+    useradd -m -g ${GROUP_ID} -u ${USER_ID} ${USER} || echo "user already exists"
 
 USER ${USER_ID}:${GROUP_ID}
 


### PR DESCRIPTION
I wanted to give support to macos on CI but from the docs:

https://docs.travis-ci.com/user/docker/

```
We do not currently support use of Docker on macOS.
```

Since the core objective is support to docker stuff, we are not going to have support for mac os on the CI and it makes kinda hard for me to test this, help will be needed from mac users x_x